### PR TITLE
Fixes and frontend double spending

### DIFF
--- a/offlineeuro/src/main/java/nl/tudelft/trustchain/offlineeuro/db/WalletManager.kt
+++ b/offlineeuro/src/main/java/nl/tudelft/trustchain/offlineeuro/db/WalletManager.kt
@@ -125,6 +125,7 @@ class WalletManager(
             digitalEuro.firstTheta1.toBytes(),
             serialize(digitalEuro.signature)!!,
             digitalEuro.amount,
+            serialize(digitalEuro.proofs),
             walletEntryMapper
         ).executeAsList().sortedByDescending { entry -> entry.receivedTimestamp }.firstOrNull()
     }

--- a/offlineeuro/src/main/java/nl/tudelft/trustchain/offlineeuro/entity/Transaction.kt
+++ b/offlineeuro/src/main/java/nl/tudelft/trustchain/offlineeuro/entity/Transaction.kt
@@ -221,13 +221,7 @@ object Transaction {
             // Verify the signed amount is currently of the expected value
             val upper = getValueUpperBound(digitalEuro)
             val shouldBe = getValueAfterFee(digitalEuro)
-            Log.d("DIGITAL EURO CONTENTS", "${digitalEuro.amount}" +
-                "withdrawal timestamp: ${digitalEuro.withdrawalTimestamp}" +
-                "current time: ${System.currentTimeMillis()}" +
-                "proof size: ${digitalEuro.proofs.size}")
-            Log.d("OfflineEuro", "Upper bound: ${upper}, should be: ${shouldBe}")
             if (!(digitalEuro.amount >= shouldBe) || !(digitalEuro.amount <= upper)) {
-                Log.d("OfflineEuro", "FAIL")
                 Log.d("OfflineEuro", "Bank amount mismatch: ${digitalEuro.amount} != ${getValueAfterFee(digitalEuro)}")
                 return false
             }

--- a/offlineeuro/src/main/java/nl/tudelft/trustchain/offlineeuro/entity/Transaction.kt
+++ b/offlineeuro/src/main/java/nl/tudelft/trustchain/offlineeuro/entity/Transaction.kt
@@ -219,7 +219,15 @@ object Transaction {
         // Only validate amount matching for non-deposits
         if (!isDeposit) {
             // Verify the signed amount is currently of the expected value
-            if (!(digitalEuro.amount >= getValueAfterFee(digitalEuro)) || !(digitalEuro.amount <= getValueUpperBound(digitalEuro))) {
+            val upper = getValueUpperBound(digitalEuro)
+            val shouldBe = getValueAfterFee(digitalEuro)
+            Log.d("DIGITAL EURO CONTENTS", "${digitalEuro.amount}" +
+                "withdrawal timestamp: ${digitalEuro.withdrawalTimestamp}" +
+                "current time: ${System.currentTimeMillis()}" +
+                "proof size: ${digitalEuro.proofs.size}")
+            Log.d("OfflineEuro", "Upper bound: ${upper}, should be: ${shouldBe}")
+            if (!(digitalEuro.amount >= shouldBe) || !(digitalEuro.amount <= upper)) {
+                Log.d("OfflineEuro", "FAIL")
                 Log.d("OfflineEuro", "Bank amount mismatch: ${digitalEuro.amount} != ${getValueAfterFee(digitalEuro)}")
                 return false
             }

--- a/offlineeuro/src/main/java/nl/tudelft/trustchain/offlineeuro/entity/Wallet.kt
+++ b/offlineeuro/src/main/java/nl/tudelft/trustchain/offlineeuro/entity/Wallet.kt
@@ -35,11 +35,13 @@ data class WalletEntry(
         Log.d("Wallet", "Transaction Info:")
         Log.d("Wallet", "Time passed: $timePassed")
         val currentTransferCount = calculateTransferCount()
+        Log.d("Current transfer count:", "$currentTransferCount")
 
         var fee = (timePassed / 24.0) * 0.05
         Log.d("Wallet", "Calculated fee: $fee")
         // No fee for the first 3 transactions
         if (currentTransferCount > 2) {
+            Log.d("TAXED", "TAX")
             fee += (currentTransferCount - 2) * 0.05
         }
 
@@ -105,6 +107,15 @@ class Wallet(
         // Check if this token is spendable (not already spent)
 //        if (walletEntry.timesSpent > 0) return null
 
+        Log.d("SPEND DIGITAL EURO CONTENTS", "${digitalEuro.amount}" +
+            "withdrawal timestamp: ${digitalEuro.withdrawalTimestamp}" +
+            "current time: ${System.currentTimeMillis()}" +
+            "proof size: ${digitalEuro.proofs.size}")
+        Log.d("SPEND WITHDRAWN DIGITAL EURO CONTENTS", "${walletEntry.digitalEuro.amount}" +
+            "withdrawal timestamp: ${walletEntry.digitalEuro.withdrawalTimestamp}" +
+            "current time: ${System.currentTimeMillis()}" +
+            "proof size: ${digitalEuro.proofs.size}")
+
         Log.d("Wallet", "Spending euro with times spent: ${walletEntry.timesSpent}")
         println("Spending euro with times spent: ${walletEntry.timesSpent}")
         walletManager.incrementTimesSpent(digitalEuro)
@@ -134,7 +145,15 @@ class Wallet(
         crs: CRS,
         deposit: Boolean
     ): TransactionDetails? {
+        Log.d("DS DIGITAL EURO CONTENTS", "${digitalEuro.amount}" +
+            "withdrawal timestamp: ${digitalEuro.withdrawalTimestamp}" +
+            "current time: ${System.currentTimeMillis()}" +
+            "proof size: ${digitalEuro.proofs.size}")
         val walletEntry = walletManager.getWalletEntryByDigitalEuro(digitalEuro) ?: return null
+        Log.d("DS WITHDRAWN DIGITAL EURO CONTENTS", "${walletEntry.digitalEuro.amount}" +
+            "withdrawal timestamp: ${walletEntry.digitalEuro.withdrawalTimestamp}" +
+            "current time: ${System.currentTimeMillis()}" +
+            "proof size: ${digitalEuro.proofs.size}")
         // Check if this token can be double spent (spent exactly once)
         if (walletEntry.timesSpent != 1L) return null
 
@@ -146,6 +165,8 @@ class Wallet(
 
         // Calculate the fee and update the value
         val valueAfterFee = walletEntry.getValueAfterFee()
+
+        Log.d("Wallet", "Spending euro with times spent: ${walletEntry.timesSpent}, value after fee: $valueAfterFee")
 
         // Create a new digital euro with the updated value
         val updatedEuro = digitalEuro.copy(amount = valueAfterFee)

--- a/offlineeuro/src/main/java/nl/tudelft/trustchain/offlineeuro/entity/Wallet.kt
+++ b/offlineeuro/src/main/java/nl/tudelft/trustchain/offlineeuro/entity/Wallet.kt
@@ -35,13 +35,11 @@ data class WalletEntry(
         Log.d("Wallet", "Transaction Info:")
         Log.d("Wallet", "Time passed: $timePassed")
         val currentTransferCount = calculateTransferCount()
-        Log.d("Current transfer count:", "$currentTransferCount")
 
         var fee = (timePassed / 24.0) * 0.05
         Log.d("Wallet", "Calculated fee: $fee")
         // No fee for the first 3 transactions
         if (currentTransferCount > 2) {
-            Log.d("TAXED", "TAX")
             fee += (currentTransferCount - 2) * 0.05
         }
 
@@ -107,16 +105,6 @@ class Wallet(
         // Check if this token is spendable (not already spent)
 //        if (walletEntry.timesSpent > 0) return null
 
-        Log.d("SPEND DIGITAL EURO CONTENTS", "${digitalEuro.amount}" +
-            "withdrawal timestamp: ${digitalEuro.withdrawalTimestamp}" +
-            "current time: ${System.currentTimeMillis()}" +
-            "proof size: ${digitalEuro.proofs.size}")
-        Log.d("SPEND WITHDRAWN DIGITAL EURO CONTENTS", "${walletEntry.digitalEuro.amount}" +
-            "withdrawal timestamp: ${walletEntry.digitalEuro.withdrawalTimestamp}" +
-            "current time: ${System.currentTimeMillis()}" +
-            "proof size: ${digitalEuro.proofs.size}")
-
-        Log.d("Wallet", "Spending euro with times spent: ${walletEntry.timesSpent}")
         println("Spending euro with times spent: ${walletEntry.timesSpent}")
         walletManager.incrementTimesSpent(digitalEuro)
 
@@ -145,15 +133,7 @@ class Wallet(
         crs: CRS,
         deposit: Boolean
     ): TransactionDetails? {
-        Log.d("DS DIGITAL EURO CONTENTS", "${digitalEuro.amount}" +
-            "withdrawal timestamp: ${digitalEuro.withdrawalTimestamp}" +
-            "current time: ${System.currentTimeMillis()}" +
-            "proof size: ${digitalEuro.proofs.size}")
         val walletEntry = walletManager.getWalletEntryByDigitalEuro(digitalEuro) ?: return null
-        Log.d("DS WITHDRAWN DIGITAL EURO CONTENTS", "${walletEntry.digitalEuro.amount}" +
-            "withdrawal timestamp: ${walletEntry.digitalEuro.withdrawalTimestamp}" +
-            "current time: ${System.currentTimeMillis()}" +
-            "proof size: ${digitalEuro.proofs.size}")
         // Check if this token can be double spent (spent exactly once)
         if (walletEntry.timesSpent != 1L) return null
 
@@ -165,8 +145,6 @@ class Wallet(
 
         // Calculate the fee and update the value
         val valueAfterFee = walletEntry.getValueAfterFee()
-
-        Log.d("Wallet", "Spending euro with times spent: ${walletEntry.timesSpent}, value after fee: $valueAfterFee")
 
         // Create a new digital euro with the updated value
         val updatedEuro = digitalEuro.copy(amount = valueAfterFee)

--- a/offlineeuro/src/main/java/nl/tudelft/trustchain/offlineeuro/ui/CallbackLibrary.kt
+++ b/offlineeuro/src/main/java/nl/tudelft/trustchain/offlineeuro/ui/CallbackLibrary.kt
@@ -67,9 +67,14 @@ object CallbackLibrary {
         // Update wallet tokens table
         val tokensList = view.findViewById<LinearLayout>(R.id.user_home_tokens_list)
         if (tokensList != null) {
-            val walletEntries = user.wallet.getAllWalletEntriesToSpend() +
-                user.wallet.getAllWalletEntriesToDoubleSpend()
-            TableHelpers.addWalletTokensToTable(tokensList, walletEntries.distinctBy { it.digitalEuro.serialNumber }, user, context)
+            val walletEntries = user.wallet.getAllWalletEntriesToSpend()
+            TableHelpers.addWalletTokensToTable(tokensList, walletEntries, user, context)
+        }
+
+        val dsTokensList = view.findViewById<LinearLayout>(R.id.user_home_ds_tokens_list)
+        if (dsTokensList != null) {
+            val dsWalletEntries = user.wallet.getAllWalletEntriesToDoubleSpend()
+            TableHelpers.addWalletTokensToTable(dsTokensList, dsWalletEntries, user, context)
         }
 
         val addressList = view.findViewById<LinearLayout>(R.id.user_home_addresslist)

--- a/offlineeuro/src/main/java/nl/tudelft/trustchain/offlineeuro/ui/TableHelpers.kt
+++ b/offlineeuro/src/main/java/nl/tudelft/trustchain/offlineeuro/ui/TableHelpers.kt
@@ -188,12 +188,20 @@ object TableHelpers {
         // Action buttons
         val buttonWrapper = LinearLayout(context)
         val params = layoutParams(0.3f)
-        buttonWrapper.gravity = Gravity.CENTER_HORIZONTAL
-        buttonWrapper.orientation = LinearLayout.HORIZONTAL
+        buttonWrapper.gravity = Gravity.CENTER
+        buttonWrapper.orientation = LinearLayout.VERTICAL
         buttonWrapper.layoutParams = params
 
         val sendButton = Button(context)
         val depositButton = Button(context)
+
+        val lp = LinearLayout.LayoutParams(
+            LinearLayout.LayoutParams.WRAP_CONTENT,
+            LinearLayout.LayoutParams.WRAP_CONTENT)
+        lp.topMargin = 4
+
+        sendButton.layoutParams = lp
+        depositButton.layoutParams = lp
 
         applyButtonStyling(sendButton, context)
         applyButtonStyling(depositButton, context)

--- a/offlineeuro/src/main/java/nl/tudelft/trustchain/offlineeuro/ui/UserHomeFragment.kt
+++ b/offlineeuro/src/main/java/nl/tudelft/trustchain/offlineeuro/ui/UserHomeFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.util.Log
 import android.view.View
 import android.widget.Button
+import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.TextView
 import android.widget.Toast
@@ -50,6 +51,18 @@ class UserHomeFragment : OfflineEuroBaseFragment(R.layout.fragment_user_home) {
             } catch (e: Exception) {
                 Toast.makeText(context, e.message, Toast.LENGTH_SHORT).show()
             }
+        }
+
+        val arrow = view.findViewById<ImageView>(R.id.ds_section_arrow)
+        val body = view.findViewById<LinearLayout>(R.id.user_home_ds_tokens_list)
+        val header = view.findViewById<LinearLayout>(R.id.ds_section_header)
+
+        header.setOnClickListener {
+            val expanded = body.visibility == View.VISIBLE
+            body.visibility = if (expanded) View.GONE else View.VISIBLE
+            arrow.setImageResource(
+                if (expanded) R.drawable.ic_baseline_outgoing_24 else R.drawable.ic_baseline_incoming_24
+            )
         }
 
         view.findViewById<Button>(R.id.user_home_reset_button).setOnClickListener {

--- a/offlineeuro/src/main/res/layout/fragment_user_home.xml
+++ b/offlineeuro/src/main/res/layout/fragment_user_home.xml
@@ -6,6 +6,15 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_gravity="center">
 
+    <androidx.core.widget.NestedScrollView
+        android:id="@+id/user_home_scroll"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:fillViewport="true"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/reset_container">
 
         <LinearLayout
             android:id="@+id/user_home_layout"
@@ -92,47 +101,144 @@
                         android:layout_height="match_parent"
                         android:gravity="center_vertical"
                         android:orientation="horizontal"
+                        android:weightSum="10"
                         android:background="@color/colorPrimary">
 
                         <TextView
+                            style="@style/TableCell"
                             android:layout_width="0dp"
                             android:layout_height="match_parent"
-                            android:layout_weight="0.2"
+                            android:layout_weight="2"
                             android:gravity="center"
+                            android:maxLines="1"
                             android:text="Amount"
                             android:textColor="@color/white" />
 
                         <TextView
+                            style="@style/TableCell"
                             android:layout_width="0dp"
                             android:layout_height="wrap_content"
                             android:text="Status"
                             android:gravity="center"
-                            android:layout_weight="0.2"
+                            android:maxLines="1"
+                            android:layout_weight="2"
                             android:textColor="@color/white" />
 
                         <TextView
+                            style="@style/TableCell"
                             android:id="@+id/textView"
-                            android:layout_width="15dp"
-                            android:layout_height="36dp"
-                            android:layout_weight="1"
-                            android:text="timestamp" />
-
-                        <TextView
                             android:layout_width="0dp"
                             android:layout_height="wrap_content"
-                            android:layout_weight="0.3"
+                            android:maxLines="1"
+                            android:layout_weight="2"
+                            android:text="Timestamp"
+                            android:textColor="@color/white" />
+
+                        <TextView
+                            style="@style/TableCell"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="2"
                             android:gravity="center"
+                            android:maxLines="1"
                             android:text="Serial#"
                             android:textColor="@color/white" />
 
                         <TextView
+                            style="@style/TableCell"
                             android:layout_width="0dp"
                             android:layout_height="wrap_content"
-                            android:layout_weight="0.3"
+                            android:layout_weight="2"
                             android:gravity="center"
+                            android:maxLines="1"
                             android:text="Actions"
                             android:textColor="@color/white" />
 
+                    </LinearLayout>
+                </LinearLayout>
+            </LinearLayout>
+
+            <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:layout_marginHorizontal="10dp">
+
+                <LinearLayout
+                    android:id="@+id/ds_section_header"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    android:gravity="center_horizontal"
+                    android:paddingVertical="8dp"
+                    android:clickable="true"
+                    android:focusable="true">
+
+                    <TextView
+                        android:id="@+id/ds_section_title"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="Tokens you can double-spend"
+                        android:textSize="16sp"
+                        android:textStyle="bold"/>
+
+                    <ImageView
+                        android:id="@+id/ds_section_arrow"
+                        android:layout_width="24dp"
+                        android:layout_height="24dp"
+                        android:src="@drawable/ic_baseline_outgoing_24"/>
+                </LinearLayout>
+
+                <LinearLayout
+                    android:id="@+id/user_home_ds_tokens_list"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:visibility="gone"
+                    android:orientation="vertical">
+
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"
+                        android:gravity="center_vertical"
+                        android:orientation="horizontal"
+                        android:weightSum="10"
+                        android:background="@color/colorPrimary">
+
+                        <TextView
+                            style="@style/TableCell"
+                            android:layout_weight="2"
+                            android:text="Amount"
+                            android:maxLines="1"
+                            android:textColor="@color/white"/>
+
+                        <TextView
+                            style="@style/TableCell"
+                            android:layout_weight="2"
+                            android:text="Status"
+                            android:maxLines="1"
+                            android:textColor="@color/white"/>
+
+                        <TextView
+                            style="@style/TableCell"
+                            android:layout_weight="2"
+                            android:text="Timestamp"
+                            android:maxLines="1"
+                            android:textColor="@color/white"/>
+
+                        <TextView
+                            style="@style/TableCell"
+                            android:layout_weight="2"
+                            android:text="Serial#"
+                            android:maxLines="1"
+                            android:textColor="@color/white"/>
+
+                        <TextView
+                            style="@style/TableCell"
+                            android:layout_weight="2"
+                            android:text="Actions"
+                            android:maxLines="1"
+                            android:textColor="@color/white"/>
                     </LinearLayout>
                 </LinearLayout>
             </LinearLayout>
@@ -243,7 +349,9 @@
                 android:layout_gravity="center_horizontal"
                 android:text="Sync Address list" />
         </LinearLayout>
+    </androidx.core.widget.NestedScrollView>
     <LinearLayout
+        android:id="@+id/reset_container"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:gravity="center_horizontal"

--- a/offlineeuro/src/main/res/layout/item_wallet_token.xml
+++ b/offlineeuro/src/main/res/layout/item_wallet_token.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/offlineeuro/src/main/sqldelight/nl/tudelft/offlineeuro/sqldelight/Wallet.sq
+++ b/offlineeuro/src/main/sqldelight/nl/tudelft/offlineeuro/sqldelight/Wallet.sq
@@ -36,7 +36,7 @@ VALUES (?, ?, ?, ?, ?, ?, ?, 0, ?, ?, ?, ?,?);
 getWalletEntryByDescriptor:
 SELECT *
 FROM Wallet
-WHERE serialNumber = ? AND firstTheta1 = ? AND signature = ? AND amount = ?;
+WHERE serialNumber = ? AND firstTheta1 = ? AND signature = ? AND amount = ? AND previousProofs = ?;
 
 getAllWalletEntries:
 SELECT *


### PR DESCRIPTION
Interface is now scrollable and looks a bit nicer.
Fixed bug in double spending.
User Home Fragment now has separate places for normal tokens and tokens that can be doubly spent. Now, there is a list that when clicked on will reveal all tokens that can be doubly spent in a drop down menu. It can be clicked again to hide those tokens.

![WhatsApp Image 2025-06-22 at 19 15 14_d015a3b9](https://github.com/user-attachments/assets/b32b7ba0-0be8-4d89-8d0e-0ad4cd28a4dd)

In the image above, the token costing €50 was previously sent to another user, and can be now doubly spent. 